### PR TITLE
Multiple fixes and some additional tests

### DIFF
--- a/unit.go
+++ b/unit.go
@@ -90,7 +90,8 @@ func NewUnit(m map[string]int64) (*Unit, error) {
 	for _, mult := range m {
 		if mult == 1 {
 			found = true
-			break
+		} else if mult == 0 {
+			return nil, fmt.Errorf("mapping contains unit that maps to illegal multiplier 0 for %v", m)
 		}
 	}
 	if !found {

--- a/unit.go
+++ b/unit.go
@@ -135,7 +135,7 @@ func (u *Unit) MustNewValue(value int64, explicitSign Sign) *Value {
 
 // ValueFromString converts the given string to a Value.
 // The string is allowed to have '+'/'-' as prefix, followed by a number, and
-// an optional unit character as defined in its mapping.
+// an optional unit name as defined in its mapping.
 func (u *Unit) ValueFromString(str string) (*Value, error) {
 	s := &Value{unit: u}
 

--- a/unit.go
+++ b/unit.go
@@ -8,6 +8,7 @@ package unit
 import (
 	"errors"
 	"fmt"
+	"math"
 	"strconv"
 	"unicode"
 )
@@ -206,6 +207,9 @@ func (s *Value) Set(str string) error {
 			return fmt.Errorf("unit %q is not valid", unitName)
 		}
 		mult = 1
+	}
+	if (value > 0 && (math.MaxInt64/mult < value)) || (value < 0 && (math.MinInt64/mult > value)) {
+		return fmt.Errorf("size %d with unit %q is out of range", value, unitName)
 	}
 	s.Value = value * mult
 	s.IsSet = true

--- a/unit_test.go
+++ b/unit_test.go
@@ -66,23 +66,23 @@ func TestUnit(t *testing.T) {
 	for _, test := range unitTests {
 		v, err := u.ValueFromString(test.in)
 		if test.err && err == nil {
-			t.Fatalf("Expected that rest '%s' returns an error\n", test.in)
+			t.Fatalf("Expected that test '%s' returns an error\n", test.in)
 		} else if !test.err && err != nil {
-			t.Fatalf("Expected that rest '%s' does not return an error\n", test.in)
+			t.Fatalf("Expected that test '%s' does not return an error\n", test.in)
 		} else if test.err && err != nil {
 			continue
 		}
 
 		if v.Value != test.value {
-			t.Fatalf("Expected that rest '%s' returns %d as bytes, but got %d\n", test.in, test.value, v.Value)
+			t.Fatalf("Expected that test '%s' returns %d as bytes, but got %d\n", test.in, test.value, v.Value)
 		}
 
 		if v.String() != test.out {
-			t.Fatalf("Expected that rest '%s' returns %s as string, but got %s\n", test.in, test.out, v)
+			t.Fatalf("Expected that test '%s' returns %s as string, but got %s\n", test.in, test.out, v)
 		}
 
 		if v.ExplicitSign != test.explicitSign {
-			t.Fatalf("Expected that rest '%s' has explicit Sign %d, but got %d\n", test.in, test.explicitSign, v.ExplicitSign)
+			t.Fatalf("Expected that test '%s' has explicit Sign %d, but got %d\n", test.in, test.explicitSign, v.ExplicitSign)
 		}
 	}
 }

--- a/unit_test.go
+++ b/unit_test.go
@@ -12,6 +12,64 @@ var m = map[string]int64{
 	"MiB": 1024 * 1024,
 }
 
+var mapTests = []struct {
+	description string
+	mapping     map[string]int64
+	expectFail  bool
+}{
+	{
+		description: "Valid map 1",
+		mapping: map[string]int64{
+			"B": 1,
+		},
+		expectFail: false,
+	}, {
+		description: "Valid map 2",
+		mapping: map[string]int64{
+			"B":   1,
+			"KiB": 1024,
+			"MiB": 1024 * 1024,
+			"GiB": 1024 * 1024 * 1024,
+			"TiB": 1024 * 1024 * 1024 * 1024,
+		},
+		expectFail: false,
+	}, {
+		description: "Valid map 3",
+		mapping: map[string]int64{
+			"B":   1,
+			"KiB": 1024,
+			"MiB": 1024 * 1024,
+			"":    1024 * 1024,
+			"GiB": 1024 * 1024 * 1024,
+			"TiB": 1024 * 1024 * 1024 * 1024,
+		},
+		expectFail: false,
+	}, {
+		description: "Invalid map 1 (empty map)",
+		mapping:     map[string]int64{},
+		expectFail:  true,
+	}, {
+		description: "Invalid map 2 (no mapping to multiplier 1)",
+		mapping: map[string]int64{
+			"KB": 1000,
+			"MB": 1000 * 1000,
+			"GB": 1000 * 1000 * 1000,
+		},
+		expectFail: true,
+	}, {
+		description: "Invalid map 3 (contains mapping to multiplier 0)",
+		mapping: map[string]int64{
+			"Bad": 0,
+			"B":   1,
+			"KiB": 1024,
+			"MiB": 1024 * 1024,
+			"GiB": 1024 * 1024 * 1024,
+			"TiB": 1024 * 1024 * 1024 * 1024,
+		},
+		expectFail: true,
+	},
+}
+
 var unitTests = []struct {
 	in, out      string
 	value        int64
@@ -25,6 +83,10 @@ var unitTests = []struct {
 	}, {
 		// With invalid unit
 		in:  "23K",
+		err: true,
+	}, {
+		// Out of range value * unit multiplication
+		in:  "18014398509482034KiB",
 		err: true,
 	}, {
 		// With valid unit
@@ -54,6 +116,18 @@ var unitTests = []struct {
 		value:        -1024 * 1024,
 		explicitSign: Negative,
 	},
+}
+
+// TestNewUnit tests the NewUnit function
+func TestNewUnit(t *testing.T) {
+	for _, test := range mapTests {
+		_, err := NewUnit(test.mapping)
+		if test.expectFail && err == nil {
+			t.Fatalf("Test case \"%s\" did not return an error as expected\n", test.description)
+		} else if !test.expectFail && err != nil {
+			t.Fatalf("Test case \"%s\" return an unexpected error: %v\n", test.description, err)
+		}
+	}
 }
 
 // TestUnit implements a table-driven test.


### PR DESCRIPTION
Commit `f8b4eade606dcded7f3e7e6a2f26427992fe5fe6` detects the case where the multiplication of a size times the unit factor would overflow and returns an error. This avoids continuing with an incorrect result.

Commit `6bedabc8de022bc03acb16a52ab19815e4bb831f` prevents mapping a unit with factor `0`, which could later cause a division by zero in Value.String().

The other commits fix some typos and add some more inputs for existing tests and add a unit test for the `NewUnit(...)` function.